### PR TITLE
Additional infos in URL

### DIFF
--- a/kinto_amo/tests/test_views.py
+++ b/kinto_amo/tests/test_views.py
@@ -30,6 +30,17 @@ class AMOTest(AMOTestCase):
 
         assert resp.content_type == "application/json"
 
+    def test_amo_view_also_match_with_metrics_args(self):
+        url = SERVICE_ENDPOINT.format(api_ver="3",
+                                      app=constants.FIREFOX_APPID,
+                                      app_ver="46.0")
+        url += ('PRODUCT/BUILD_ID/BUILD_TARGET/LOCALE/CHANNEL/'
+                'OS_VERSION/DISTRIBUTION/DISTRIBUTION_VERSION/'
+                'PING_COUNT/TOTAL_PING_COUNT/DAYS_SINCE_LAST_PING/')
+        resp = self.app.get(url)
+
+        assert resp.content_type == "application/xml"
+
     def test_amo_views_passes_api_ver_and_app_args_to_addons_exporter(self):
         with mock.patch('kinto_amo.views.services.write_addons_items') as wai:
             url = SERVICE_ENDPOINT.format(api_ver="3",

--- a/kinto_amo/views/services.py
+++ b/kinto_amo/views/services.py
@@ -6,7 +6,8 @@ from kinto2xml.exporter import (
 )
 from lxml import etree
 
-path = '/blocklist/{api_ver:\d+}/{application_guid}/{application_ver}/'
+path = ('/blocklist/{api_ver:\d+}/{application_guid}/{application_ver}/'
+        '{metrics:.*}')
 
 PARENT_PATTERN = "/buckets/{bucket}/collections/{collection}"
 


### PR DESCRIPTION
In Gecko, the current XML url is this:
```
pref("extensions.blocklist.url", "https://blocklist.addons.mozilla.org/blocklist/3/%APP_ID%/%APP_VERSION%/%PRODUCT%/%BUILD_ID%/%BUILD_TARGET%/%LOCALE%/%CHANNEL%/%OS_VERSION%/%DISTRIBUTION%/%DISTRIBUTION_VERSION%/%PING_COUNT%/%TOTAL_PING_COUNT%/%DAYS_SINCE_LAST_PING%/");
```
https://dxr.mozilla.org/mozilla-central/rev/6adc822f5e27a55551faeb6c47a9bd8b0859a23b/toolkit/mozapps/extensions/nsBlocklistService.js#516-579

The current path won't allow this and will return a 404 : https://github.com/mozilla-services/kinto-amo/blob/6559edb008510a1f722f5fc05677df7485936757/kinto_amo/views/services.py#L4