### PR TITLE
Add end-to-end functional test on Travis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
-*.pyc
-.coverage
-.tox/
 *.egg-info/
-__pycache__/
+*.pyc
 .cache/
+.coverage
+.eggs/
+.tox/
+.venv/
+__pycache__/
+schemas.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,11 @@ env:
     - TOX_ENV=py27
     - TOX_ENV=py34
     - TOX_ENV=kinto-master
+    - TOX_ENV=functional
     - TOX_ENV=flake8
+matrix:
+  allow_failures:
+    - env: TOX_ENV=functional
 install:
     - make install
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,11 +19,6 @@ matrix:
         - make install
         - pip install -U https://github.com/Kinto/kinto/zipball/master
         - make run-kinto &
-  allow_failures:
-    - env:
-        - TOX_ENV=functional
-        - TOX_ENV=functional
-          WITH=kinto-master
 install:
     - make install
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,24 +8,22 @@ env:
 matrix:
   include:
     - env:
-	    - TOX_ENV=functional
+        - TOX_ENV=functional
       install:
-        - pip install --user virtualenv tox
         - make install install-kinto
         - make run-kinto &
     - env:
-	    - TOX_ENV=functional
-		  WITH=kinto-master
+        - TOX_ENV=functional
+          WITH=kinto-master
       install:
-        - pip install --user virtualenv tox
         - make install
         - .venv/bin/pip install -U https://github.com/Kinto/kinto/zipball/master
         - make run-kinto &
   allow_failures:
     - env:
-	    - TOX_ENV=functional
-		- TOX_ENV=functional
-		  WITH=kinto-master
+        - TOX_ENV=functional
+        - TOX_ENV=functional
+          WITH=kinto-master
 install:
     - make install
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,28 @@ env:
     - TOX_ENV=py27
     - TOX_ENV=py34
     - TOX_ENV=kinto-master
-    - TOX_ENV=functional
     - TOX_ENV=flake8
 matrix:
+  include:
+    - env:
+	    - TOX_ENV=functional
+      install:
+        - pip install --user virtualenv tox
+        - make install install-kinto
+        - make run-kinto &
+    - env:
+	    - TOX_ENV=functional
+		  WITH=kinto-master
+      install:
+        - pip install --user virtualenv tox
+        - make install
+        - .venv/bin/pip install -U https://github.com/Kinto/kinto/zipball/master
+        - make run-kinto &
   allow_failures:
-    - env: TOX_ENV=functional
+    - env:
+	    - TOX_ENV=functional
+		- TOX_ENV=functional
+		  WITH=kinto-master
 install:
     - make install
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ matrix:
           WITH=kinto-master
       install:
         - make install
-        - .venv/bin/pip install -U https://github.com/Kinto/kinto/zipball/master
+        - pip install -U https://github.com/Kinto/kinto/zipball/master
         - make run-kinto &
   allow_failures:
     - env:

--- a/Makefile
+++ b/Makefile
@@ -22,9 +22,6 @@ virtualenv: $(PYTHON)
 $(PYTHON):
 	virtualenv $(VENV)
 
-moto:
-	$(VENV)/bin/moto_server s3bucket_path -H 0.0.0.0 -p 5000
-
 tests-once: install
 	$(VENV)/bin/tox -e py27
 

--- a/config/kinto.ini
+++ b/config/kinto.ini
@@ -16,9 +16,9 @@ use = egg:kinto
 #
 # http://kinto.readthedocs.io/en/latest/configuration/settings.html#storage
 #
-kinto.storage_backend = cliquet.storage.memory
-kinto.cache_backend = cliquet.cache.memory
-kinto.permission_backend = cliquet.permission.memory
+kinto.storage_backend = kinto.core.storage.memory
+kinto.cache_backend = kinto.core.cache.memory
+kinto.permission_backend = kinto.core.permission.memory
 
 #
 # Auth configuration.
@@ -31,15 +31,19 @@ multiauth.policies = basicauth
 kinto.experimental_collection_schema_validation = true
 
 kinto.includes = kinto_amo
+kinto.amo.addons = '/buckets/staging/collections/addons'
+kinto.amo.plugins = '/buckets/staging/collections/plugins'
+kinto.amo.gfx = '/buckets/staging/collections/gfx'
+kinto.amo.certificates = '/buckets/staging/collections/certificates'
 
 #
 # Logging configuration
 #
 
-# kinto.logging_renderer = cliquet.logs.ClassicLogRenderer
+# kinto.logging_renderer = kinto.core.logs.ClassicLogRenderer
 
 [loggers]
-keys = root, cliquet
+keys = root, kinto
 
 [handlers]
 keys = console
@@ -51,10 +55,10 @@ keys = generic
 level = INFO
 handlers = console
 
-[logger_cliquet]
+[logger_kinto]
 level = DEBUG
 handlers =
-qualname = cliquet
+qualname = kinto
 
 [handler_console]
 class = StreamHandler

--- a/config/kinto.ini
+++ b/config/kinto.ini
@@ -1,0 +1,66 @@
+# Created at Tue, 15 Mar 2016 11:24:21 +0100
+# Using Kinto version 2.0.0
+
+
+[server:main]
+use = egg:waitress#main
+host = 0.0.0.0
+port = 8888
+
+
+[app:main]
+use = egg:kinto
+
+#
+# Backends.
+#
+# http://kinto.readthedocs.io/en/latest/configuration/settings.html#storage
+#
+kinto.storage_backend = cliquet.storage.memory
+kinto.cache_backend = cliquet.cache.memory
+kinto.permission_backend = cliquet.permission.memory
+
+#
+# Auth configuration.
+#
+# userid_hmac_secret is made for preventing guessing the basicauth id from a login:pass
+kinto.userid_hmac_secret = d32712c82034ec704828ff9038c5926fca11463fb92130dd70d8ae7d593294c5
+multiauth.policies = basicauth
+
+# Enable schema because xml2kinto uses them
+kinto.experimental_collection_schema_validation = true
+
+kinto.includes = kinto_amo
+
+#
+# Logging configuration
+#
+
+# kinto.logging_renderer = cliquet.logs.ClassicLogRenderer
+
+[loggers]
+keys = root, cliquet
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = INFO
+handlers = console
+
+[logger_cliquet]
+level = DEBUG
+handlers =
+qualname = cliquet
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(asctime)s %(levelname)-5.5s [%(name)s][%(threadName)s] %(message)s

--- a/tox.ini
+++ b/tox.ini
@@ -20,3 +20,10 @@ install_command = pip install --pre {opts} {packages}
 commands = flake8 kinto_amo
 deps =
     flake8
+
+[testenv:functional]
+whitelist_externals=make
+commands =
+    make update-schemas
+    json2kinto -s http://localhost:8888/v1 --addons-server https://addons.mozilla.org/ -S schemas.json
+	xml-verifier https://blocklist.addons.mozilla.org/blocklist/3/\{ec8030f7-c20a-464f-9b0e-13a3a9e97384\}/46.0/ http://localhost:8888/v1/blocklist/3/\{ec8030f7-c20a-464f-9b0e-13a3a9e97384\}/46.0/

--- a/tox.ini
+++ b/tox.ini
@@ -25,5 +25,5 @@ deps =
 whitelist_externals=make
 commands =
     make update-schemas
-    # json2kinto -s http://localhost:8888/v1 --addons-server https://addons.mozilla.org/ -S schemas.json
-	xml-verifier https://blocklist.addons.mozilla.org/blocklist/3/\{ec8030f7-c20a-464f-9b0e-13a3a9e97384\}/46.0/ https://kinto-reader.dev.mozaws.net/v1/blocklist/3/\{ec8030f7-c20a-464f-9b0e-13a3a9e97384\}/46.0/
+    json2kinto -s http://localhost:8888/v1 --addons-server https://addons.mozilla.org/ -S schemas.json
+    xml-verifier 'https://blocklist.addons.mozilla.org/blocklist/3/\{ec8030f7-c20a-464f-9b0e-13a3a9e97384\}/46.0/' 'http://localhost:8888/v1/blocklist/3/\{ec8030f7-c20a-464f-9b0e-13a3a9e97384\}/46.0/'

--- a/tox.ini
+++ b/tox.ini
@@ -25,5 +25,5 @@ deps =
 whitelist_externals=make
 commands =
     make update-schemas
-    json2kinto -s http://localhost:8888/v1 --addons-server https://addons.mozilla.org/ -S schemas.json
-	xml-verifier https://blocklist.addons.mozilla.org/blocklist/3/\{ec8030f7-c20a-464f-9b0e-13a3a9e97384\}/46.0/ http://localhost:8888/v1/blocklist/3/\{ec8030f7-c20a-464f-9b0e-13a3a9e97384\}/46.0/
+    # json2kinto -s http://localhost:8888/v1 --addons-server https://addons.mozilla.org/ -S schemas.json
+	xml-verifier https://blocklist.addons.mozilla.org/blocklist/3/\{ec8030f7-c20a-464f-9b0e-13a3a9e97384\}/46.0/ https://kinto-reader.dev.mozaws.net/v1/blocklist/3/\{ec8030f7-c20a-464f-9b0e-13a3a9e97384\}/46.0/


### PR DESCRIPTION
Revamped https://github.com/mozilla-services/kinto-amo/pull/3#issuecomment-215133924
- Runs kinto with plugin enabled
- Download blocklists.xml from prod
- Loads with prod data with `json2kinto`
- Add a second kinto instance read-only
- Fetch the XML views via the read-only instance
- For each combination of (api_ver, version, app_version) test that verifier has no difference 
