### PR TITLE
update cliquet references to kinto.core

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,8 @@ CHANGELOG
 0.2.0 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Update to ``kinto.core`` for compatibility with Kinto 3.0. This
+  release is no longer compatible with Kinto < 3.0, please upgrade!
 
 
 0.1.1 (2016-05-06)

--- a/kinto_amo/tests/support.py
+++ b/kinto_amo/tests/support.py
@@ -1,8 +1,8 @@
 import os
 import webtest
 
-from cliquet.tests import support as cliquet_support
-from cliquet.tests.support import unittest
+from kinto.tests.core import support as kinto_support
+from kinto.tests.core.support import unittest
 
 
 class AMOTestCase(unittest.TestCase):
@@ -11,5 +11,5 @@ class AMOTestCase(unittest.TestCase):
         self.config = 'config.ini'
         curdir = os.path.dirname(os.path.realpath(__file__))
         app = webtest.TestApp("config:%s" % self.config, relative_to=curdir)
-        app.RequestClass = cliquet_support.get_request_class(prefix="v1")
+        app.RequestClass = kinto_support.get_request_class(prefix="v1")
         self.app = app

--- a/kinto_amo/views/services.py
+++ b/kinto_amo/views/services.py
@@ -1,5 +1,5 @@
-from cliquet import Service, utils
-from cliquet.storage import Filter
+from kinto.core import Service, utils
+from kinto.core.storage import Filter
 
 from amo2kinto.exporter import (
     write_addons_items, write_plugin_items, write_gfx_items, write_cert_items


### PR DESCRIPTION
This updates kinto-amo according to the changes made in https://github.com/Kinto/kinto/releases/tag/3.0.0.