### PR TITLE
Update kinto_amo to minimize blocklist size for modern Firefox

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,7 @@ CHANGELOG
 0.5.0 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Pass application ID and version to amo2kinto code when generating blocklist.xml. (#23)
 
 
 0.4.0 (2017-07-05)

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,5 @@
 flake8
-pytest
+pytest==3.3.2
 pytest-cache
 pytest-cover
 pytest-sugar

--- a/kinto_amo/tests/fixtures.json
+++ b/kinto_amo/tests/fixtures.json
@@ -14,7 +14,7 @@
         "targetApplication": [{
           "minVersion": "39.0a1",
           "guid": "{ec8030f7-c20a-464f-9b0e-13a3a9e97384}",
-          "maxVersion": "*"}],
+          "maxVersion": "57.0"}],
         "minVersion": "0",
         "maxVersion": "*",
         "severity": 3}],
@@ -54,7 +54,7 @@
         "targetApplication": [{
           "minVersion": "4.0",
           "guid": "{ec8030f7-c20a-464f-9b0e-13a3a9e97384}",
-          "maxVersion": "16.*"}],
+          "maxVersion": "46.*"}],
         "minVersion": "0",
         "maxVersion": "10.2.9999",
         "severity": 0,

--- a/kinto_amo/views/services.py
+++ b/kinto_amo/views/services.py
@@ -70,11 +70,11 @@ def get_blocklist(request):
         lastupdate='%s' % last_update
     )
 
-    write_addons_items(xml_tree, addons_records, api_ver=api_ver, app_id=app)
+    write_addons_items(xml_tree, addons_records, api_ver=api_ver, app_id=app, app_ver=app_ver)
     write_plugin_items(xml_tree, plugin_records, api_ver=api_ver,
                        app_id=app, app_ver=app_ver)
     write_gfx_items(xml_tree, gfx_records, api_ver=api_ver, app_id=app)
-    write_cert_items(xml_tree, cert_records, api_ver=api_ver)
+    write_cert_items(xml_tree, cert_records, api_ver=api_ver, app_id=app, app_ver=app_ver)
 
     doc = etree.ElementTree(xml_tree)
     request.response.content_type = "application/xml;charset=UTF-8"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-amo2kinto==3.1.0
+amo2kinto==3.2.0
 bcrypt==3.1.4
 certifi==2017.11.5
 cffi==1.11.2

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ with codecs.open(os.path.join(here, 'CHANGELOG.rst'), encoding='utf-8') as f:
 
 requirements = [
     'kinto>=4.0.0',
-    'amo2kinto',
+    'amo2kinto>=3.2.0',
 ]
 
 test_requirements = [


### PR DESCRIPTION
This relies on https://github.com/mozilla-services/amo2kinto/pull/75 and https://github.com/mozilla-services/amo2kinto/pull/74 being present in `amo2kinto`.